### PR TITLE
package.json dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@eqworks/omni-search",
-  "version": "0.2.1",
+  "version": "0.2.2",
   "description": "EQWorks workflow omni search component and hook",
   "main": "dist/index.js",
   "source": "src/index.js",
@@ -65,6 +65,7 @@
     "react-test-renderer": "^16.13.1"
   },
   "dependencies": {
+    "@material-ui/icons": "^4.9.1",
     "algoliasearch": "^4.1.0",
     "classnames": "^2.2.6",
     "prop-types": "^15.7.2",


### PR DESCRIPTION
when importing the package can't resolve icons, apparently has to be in `dependencies`
![image](https://user-images.githubusercontent.com/53827690/86049346-fd05f500-ba1f-11ea-84d3-366c128f2b75.png)
